### PR TITLE
feat: Add Unshare functionality to key service and share service

### DIFF
--- a/app/share.go
+++ b/app/share.go
@@ -20,3 +20,19 @@ func (a *App) Share(path string, publicKey string, encryptedPrivateKey string) c
 	}
 	return core.NewAppResult()
 }
+
+// Unshare removes the sharing of a file or directory with a specific public key.
+// It initializes the app services and calls the UnshareByPublicKey method of the shareService.
+// If an error occurs during the unsharing process, it returns an AppResult with the error.
+// Otherwise, it returns a successful AppResult.
+func (a *App) Unshare(path string, publicKey string) core.AppResult {
+	// init the app
+	initRes := a.initServices()
+	if !initRes.Ok {
+		return initRes
+	}
+	if err := a.shareService.Unshare(path, publicKey); err != nil {
+		return core.NewAppResultWithError(err)
+	}
+	return core.NewAppResult()
+}

--- a/cmd/unshare.go
+++ b/cmd/unshare.go
@@ -1,0 +1,30 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// unshareCmd represents the unshare command
+var unshareCmd = &cobra.Command{
+	Use:   "unshare",
+	Short: "Unshare files with other users",
+	Long:  `This command unshares file or directory with the specified path with the given public key.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		path := args[0]
+		recipient, _ := cmd.Flags().GetString("recipient")
+		res := ctbApp.Unshare(path, recipient)
+		MarshalOutput(res)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(unshareCmd)
+	unshareCmd.PersistentFlags().StringP("recipient", "r", "", "recipient public key. Required.")
+	err := unshareCmd.MarkPersistentFlagRequired("recipient")
+	if err != nil {
+		panic(err)
+	}
+}

--- a/core/services.go
+++ b/core/services.go
@@ -45,4 +45,5 @@ type KeyService interface {
 	IsUserJoined() bool
 	GetHasAccessToKey(keyId string, startVaultId string, userId string) (bool, bool)
 	GetKeyAccessList(keyId string, startVaultId string) (KeyAccessList, error)
+	Unshare(keyId string, recipientUserId string) error
 }

--- a/repositories/key_repository.go
+++ b/repositories/key_repository.go
@@ -20,6 +20,7 @@ type KeyRepository interface {
 	IsUserJoined(userId string) bool
 	JoinUser(userId string) error
 	ListUsers() ([]string, error)
+	DeleteDataKey(keyID string, userId string) error
 }
 
 type KeyRepositoryFile struct {
@@ -130,4 +131,20 @@ func (k *KeyRepositoryFile) ListUsers() ([]string, error) {
 		}
 	}
 	return users, nil
+}
+
+// DeleteDataKey deletes the data key associated with the given keyID and userId.
+// It removes the file corresponding to the keyID from the user's data path.
+// If an error occurs during the deletion process, it is returned.
+func (k *KeyRepositoryFile) DeleteDataKey(keyID string, userId string) error {
+	datapath, err := k.getDataPath(userId)
+	if err != nil {
+		return err
+	}
+	p := filepath.Join(datapath, keyID)
+	err = os.Remove(p)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/services/key_service/key_service.go
+++ b/services/key_service/key_service.go
@@ -425,3 +425,10 @@ func (ks *KeyStoreDefault) GetKeyAccessList(keyId string, startVaultId string) (
 	}
 	return accessList, nil
 }
+
+// Unshare removes the sharing of a data key with a recipient user.
+// It takes the key ID and the recipient user ID as parameters.
+// Returns an error if there was a problem deleting the data key.
+func (ks *KeyStoreDefault) Unshare(keyId string, recipientUserId string) error {
+	return ks.keyRepository.DeleteDataKey(keyId, recipientUserId)
+}

--- a/services/share_service/share_service.go
+++ b/services/share_service/share_service.go
@@ -97,3 +97,18 @@ func (s *Service) GetAccessList(path string) (core.KeyAccessList, error) {
 
 	return s.keyService.GetKeyAccessList(keyId, startVaultId)
 }
+
+// Unshare removes the sharing of a file or directory specified by the given path
+// with the public key provided. It returns an error if the operation fails.
+func (s *Service) Unshare(path string, publicKeyEncoded string) error {
+	keyId, _, err := s.GetKeyIdByPath(path)
+	if err != nil {
+		return err
+	}
+	err = s.keyService.Unshare(keyId, publicKeyEncoded)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added a new method to both key service and share service to allow unsharing a file or directory with a specific public key. The Unshare method removes the sharing of the specified path with the provided public key, deleting the associated data key and file. This adds new functionality for unsharing files with other users.